### PR TITLE
7.0 remove ref to "camptocamp_logo"

### DIFF
--- a/base_headers_webkit/base_headers_data.xml
+++ b/base_headers_webkit/base_headers_data.xml
@@ -53,7 +53,7 @@
     <body style="border:0; margin: 0;" onload="subst()">
         <table class="header" style="border-bottom: 0px solid black; width: 100%">
             <tr>
-                <td>${helper.embed_logo_by_name('camptocamp_logo')|n}</td>
+                <td>${helper.embed_company_logo()|safe}</td>
                 <td style="text-align:right"> </td>
             </tr>
             <tr>


### PR DESCRIPTION
and use a more neutral 'company_logo' name (backported from 8.0 PR)
