### PR TITLE
[7.0] [ADD] webkit multi header

### DIFF
--- a/report_webkit_multi_header/__init__.py
+++ b/report_webkit_multi_header/__init__.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import (
+    ir_report,
+    webkit_report,
+)

--- a/report_webkit_multi_header/__openerp__.py
+++ b/report_webkit_multi_header/__openerp__.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Webkit Report Multi Header',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'category': 'Reports/Webkit',
+    'summary': 'Allows rendering the report header/footer for each object',
+    'description': """
+This module allows you to render the webkit report page headers or footers 
+independently for each object. This lets you include object-specific fields
+in the header even when the report covers multiple objects.
+
+
+Contributors
+------------
+* Vincent Vinet (vincent.vinet@savoirfairelinux.com)
+""",
+    'depends': [
+        'report_webkit',
+    ],
+    'external_dependencies': {
+        'python': [],
+    },
+    'data': [
+        'ir_report_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/report_webkit_multi_header/__openerp__.py
+++ b/report_webkit_multi_header/__openerp__.py
@@ -30,7 +30,7 @@
     'category': 'Reports/Webkit',
     'summary': 'Allows rendering the report header/footer for each object',
     'description': """
-This module allows you to render the webkit report page headers or footers 
+This module allows you to render the webkit report page headers or footers
 independently for each object. This lets you include object-specific fields
 in the header even when the report covers multiple objects.
 

--- a/report_webkit_multi_header/i18n/fr.po
+++ b/report_webkit_multi_header/i18n/fr.po
@@ -1,0 +1,97 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* report_webkit_multi_header
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-26 13:57+0000\n"
+"PO-Revision-Date: 2014-11-26 09:04-0500\n"
+"Last-Translator: Vincent Vinet <vincent.vinet@savoirfairelinux.com>\n"
+"Language-Team: Savoir-faire Linux\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Language: fr_CA\n"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:91
+#, python-format
+msgid "Error!"
+msgstr "Erreur!"
+
+#. module: report_webkit_multi_header
+#: field:ir.actions.report.xml,multi_mode:0
+msgid "Multi Mode"
+msgstr "Mode multi en-tête"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:227
+#, python-format
+msgid "No diagnosis message was provided"
+msgstr "Aucun message d'erreur fourni"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:97
+#, python-format
+msgid "No header defined for this Webkit report!"
+msgstr "Aucun en-tête défini pour ce rapport Webkit"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:98
+#, python-format
+msgid "Please set a header in company settings."
+msgstr "Veuillez renseigner un en-tête dans les réglages de la compagnie."
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:235
+#, python-format
+msgid "The command 'wkhtmltopdf' failed with error code = %s.Message: %s"
+msgstr ""
+"La commande 'wkhtmltopdf' a échoué avec le code d'erreur = %s. Message: %s"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:229
+#, python-format
+msgid "The following diagnosis message was provided:\n"
+msgstr "Le message d'erreur suivant a été fourni:\n"
+
+#. module: report_webkit_multi_header
+#: help:ir.actions.report.xml,multi_mode:0
+msgid ""
+"This mode allows rendering the header and footer for each object of the "
+"report."
+msgstr ""
+"Ce mode permet le rendu indépendant de l'en-tête et du pied de page pour "
+"chaque objet du rapport."
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:234
+#, python-format
+msgid "Webkit error"
+msgstr "Erreur Webkit"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:129
+#: code:addons/report_webkit_multi_header/webkit_report.py:138
+#: code:addons/report_webkit_multi_header/webkit_report.py:151
+#: code:addons/report_webkit_multi_header/webkit_report.py:166
+#, python-format
+msgid "Webkit render!"
+msgstr "Rendu Webkit!"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:92
+#, python-format
+msgid "Webkit report template not found!"
+msgstr "Gabarit de rapport Webkit non trouvé!"
+
+#. module: report_webkit_multi_header
+#: code:_description:0
+#: model:ir.model,name:report_webkit_multi_header.model_ir_actions_report_xml
+#, python-format
+msgid "ir.actions.report.xml"
+msgstr ""

--- a/report_webkit_multi_header/i18n/report_webkit_multi_header.pot
+++ b/report_webkit_multi_header/i18n/report_webkit_multi_header.pot
@@ -1,0 +1,92 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* report_webkit_multi_header
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-26 13:57+0000\n"
+"PO-Revision-Date: 2014-11-26 13:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:91
+#, python-format
+msgid "Error!"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: field:ir.actions.report.xml,multi_mode:0
+msgid "Multi Mode"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:227
+#, python-format
+msgid "No diagnosis message was provided"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:97
+#, python-format
+msgid "No header defined for this Webkit report!"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:98
+#, python-format
+msgid "Please set a header in company settings."
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:235
+#, python-format
+msgid "The command 'wkhtmltopdf' failed with error code = %s.Message: %s"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:229
+#, python-format
+msgid "The following diagnosis message was provided:\n"
+""
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: help:ir.actions.report.xml,multi_mode:0
+msgid "This mode allows rendering the header and footer for each object of the report."
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:234
+#, python-format
+msgid "Webkit error"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:129
+#: code:addons/report_webkit_multi_header/webkit_report.py:138
+#: code:addons/report_webkit_multi_header/webkit_report.py:151
+#: code:addons/report_webkit_multi_header/webkit_report.py:166
+#, python-format
+msgid "Webkit render!"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:addons/report_webkit_multi_header/webkit_report.py:92
+#, python-format
+msgid "Webkit report template not found!"
+msgstr ""
+
+#. module: report_webkit_multi_header
+#: code:_description:0
+#: model:ir.model,name:report_webkit_multi_header.model_ir_actions_report_xml
+#, python-format
+msgid "ir.actions.report.xml"
+msgstr ""
+

--- a/report_webkit_multi_header/ir_report.py
+++ b/report_webkit_multi_header/ir_report.py
@@ -1,0 +1,59 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.report.report_sxw import rml_parse
+from openerp import netsvc
+
+from .webkit_report import WebKitMultiParser
+
+
+def register_report(name, model, tmpl_path, parser=rml_parse):
+    """Register the report into the services"""
+    name = 'report.%s' % name
+    if netsvc.Service._services.get(name, False):
+        service = netsvc.Service._services[name]
+        if isinstance(service, WebKitMultiParser):
+            #already instantiated properly, skip it
+            return
+        if hasattr(service, 'parser'):
+            parser = service.parser
+        del netsvc.Service._services[name]
+    WebKitMultiParser(name, model, tmpl_path, parser=parser)
+
+class Report(orm.Model):
+    _name = _inherit = 'ir.actions.report.xml'
+
+    _columns = {
+        'multi_mode': fields.boolean(
+            'Multi Mode',
+            help='This mode allows rendering the header and footer for each'
+                 ' object of the report.'),
+    }
+
+    def register_all(self,cursor):
+        value = super(Report, self).register_all(cursor)
+        cursor.execute("SELECT * FROM ir_act_report_xml WHERE report_type = 'webkit'")
+        records = cursor.dictfetchall()
+        for record in records:
+            register_report(record['report_name'], record['model'], record['report_rml'])
+        return value

--- a/report_webkit_multi_header/ir_report.py
+++ b/report_webkit_multi_header/ir_report.py
@@ -33,12 +33,13 @@ def register_report(name, model, tmpl_path, parser=rml_parse):
     if netsvc.Service._services.get(name, False):
         service = netsvc.Service._services[name]
         if isinstance(service, WebKitMultiParser):
-            #already instantiated properly, skip it
+            # already instantiated properly, skip it
             return
         if hasattr(service, 'parser'):
             parser = service.parser
         del netsvc.Service._services[name]
     WebKitMultiParser(name, model, tmpl_path, parser=parser)
+
 
 class Report(orm.Model):
     _name = _inherit = 'ir.actions.report.xml'
@@ -50,10 +51,12 @@ class Report(orm.Model):
                  ' object of the report.'),
     }
 
-    def register_all(self,cursor):
+    def register_all(self, cursor):
         value = super(Report, self).register_all(cursor)
-        cursor.execute("SELECT * FROM ir_act_report_xml WHERE report_type = 'webkit'")
+        cursor.execute("SELECT * FROM ir_act_report_xml "
+                       "WHERE report_type = 'webkit'")
         records = cursor.dictfetchall()
         for record in records:
-            register_report(record['report_name'], record['model'], record['report_rml'])
+            register_report(record['report_name'], record['model'],
+                            record['report_rml'])
         return value

--- a/report_webkit_multi_header/ir_report_view.xml
+++ b/report_webkit_multi_header/ir_report_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<openerp>
+  <data>
+    <record id="act_report_xml_view" model="ir.ui.view">
+      <field name="name">ir.actions.report.xml.inherit</field>
+      <field name="model">ir.actions.report.xml</field>
+      <field name="inherit_id" ref="report_webkit.act_report_xml_view"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='precise_mode']" position="after">
+          <field name="multi_mode"/>
+        </xpath>
+      </field>
+    </record>
+  </data>
+</openerp>
+

--- a/report_webkit_multi_header/webkit_report.py
+++ b/report_webkit_multi_header/webkit_report.py
@@ -196,7 +196,7 @@ class WebKitMultiParser(WebKitParser):
                     str(val).replace(", ", "."),
                 ])
 
-        for idx, (html, head, foot) in pages:
+        for idx, (html, head, foot) in enumerate(pages):
             body_file = os.path.join(tmpdir, "body{0}.html".format(idx))
             with open(body_file, "wb") as f:
                 f.write(self._sanitize_html(html))

--- a/report_webkit_multi_header/webkit_report.py
+++ b/report_webkit_multi_header/webkit_report.py
@@ -52,8 +52,8 @@ def log_rmtree_error(func, path, exc_info):
 
 
 class WebKitMultiParser(WebKitParser):
+    """ WebKit Parser with per-object header/footer """
 
-    # override needed to keep the attachments storing procedure
     def create_single_pdf(self, cursor, uid, ids, data, report_xml,
                           context=None):
         """generate the PDF"""
@@ -217,7 +217,6 @@ class WebKitMultiParser(WebKitParser):
         command.append(out_filename)
         stderr_path = os.path.join(tmpdir, "stderr.out")
         try:
-            print " ".join(command)
             with open(stderr_path, "w") as stderr_fd:
                 status = subprocess.call(command, stderr=stderr_fd)
             try:

--- a/report_webkit_multi_header/webkit_report.py
+++ b/report_webkit_multi_header/webkit_report.py
@@ -1,0 +1,245 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from functools import partial
+
+from mako import exceptions
+
+from openerp.addons.report_webkit import webkit_report, report_helper
+from openerp import addons
+from openerp import pooler
+from openerp import tools
+from openerp.osv import orm
+from openerp.tools.translate import _
+
+mako_template = webkit_report.mako_template
+WebKitHelper = report_helper.WebKitHelper
+WebKitParser = webkit_report.WebKitParser
+
+_logger = logging.getLogger(__name__)
+
+
+def log_rmtree_error(func, path, exc_info):
+    _logger.error('cannot %s %s: %s',
+                  {"listdir": "list dir",
+                   "remove": "delete",
+                   "rmdir": "remove dir"}.get(func.__name__),
+                  path, exc_info[0])
+
+
+class WebKitMultiParser(WebKitParser):
+
+    # override needed to keep the attachments storing procedure
+    def create_single_pdf(self, cursor, uid, ids, data, report_xml,
+                          context=None):
+        """generate the PDF"""
+
+        if context is None:
+            context = {}
+        if report_xml.report_type != 'webkit':
+            return super(WebKitParser, self).create_single_pdf(
+                cursor, uid, ids, data, report_xml, context=context)
+
+        if not report_xml.multi_mode:
+            return super(WebKitMultiParser, self).create_single_pdf(
+                cursor, uid, ids, data, report_xml, context=context)
+
+        parser_instance = self.parser(cursor,
+                                      uid,
+                                      self.name2,
+                                      context=context)
+
+        self.pool = pooler.get_pool(cursor.dbname)
+        objs = self.getObjects(cursor, uid, ids, context)
+        parser_instance.set_context(objs, data, ids, report_xml.report_type)
+
+        template = False
+
+        if report_xml.report_file:
+            # backward-compatible if path in Windows format
+            report_path = report_xml.report_file.replace("\\", "/")
+            path = addons.get_module_resource(*report_path.split('/'))
+            if path and os.path.exists(path):
+                template = file(path).read()
+        if not template and report_xml.report_webkit_data:
+            template = report_xml.report_webkit_data
+        if not template:
+            raise orm.except_orm(_('Error!'),
+                                 _('Webkit report template not found!'))
+        header = report_xml.webkit_header.html
+        footer = report_xml.webkit_header.footer_html
+        if not header and report_xml.header:
+            raise orm.except_orm(
+                _('No header defined for this Webkit report!'),
+                _('Please set a header in company settings.')
+            )
+        if not report_xml.header:
+            header = ''
+            default_head = addons.get_module_resource('report_webkit',
+                                                      'default_header.html')
+            with open(default_head, 'r') as f:
+                header = f.read()
+        css = report_xml.webkit_header.css
+        if not css:
+            css = ''
+
+        translate_call = partial(self.translate_call, parser_instance)
+        pages = []
+        body_mako_tpl = mako_template(template)
+        head_mako_tpl = mako_template(header)
+        foot_mako_tpl = mako_template(footer) if footer else None
+        helper = WebKitHelper(cursor, uid, report_xml.id, context)
+        objs = parser_instance.localcontext['objects']
+        parser_instance.localcontext['all_objects'] = objs
+        for obj in objs:
+            html, head, foot = None, None, None
+            parser_instance.localcontext['objects'] = [obj]
+            try:
+                html = body_mako_tpl.render(helper=helper,
+                                            css=css,
+                                            _=translate_call,
+                                            **parser_instance.localcontext)
+            except Exception:
+                msg = exceptions.text_error_template().render()
+                _logger.error(msg)
+                raise orm.except_orm(_('Webkit render!'), msg)
+            try:
+                head = head_mako_tpl.render(helper=helper,
+                                            css=css,
+                                            _=translate_call,
+                                            _debug=False,
+                                            **parser_instance.localcontext)
+            except Exception:
+                raise orm.except_orm(
+                    _('Webkit render!'),
+                    exceptions.text_error_template().render(),
+                )
+
+            if foot_mako_tpl:
+                try:
+                    foot = foot_mako_tpl.render(helper=helper,
+                                                css=css,
+                                                _=translate_call,
+                                                **parser_instance.localcontext)
+                except:
+                    msg = exceptions.text_error_template().render()
+                    _logger.error(msg)
+                    raise orm.except_orm(_('Webkit render!'), msg)
+
+            pages.append((html, head, foot))
+
+        if report_xml.webkit_debug:
+            try:
+                deb = head_mako_tpl.render(
+                    helper=helper,
+                    css=css,
+                    _debug=tools.ustr("\n".join(p[0] for p in pages)),
+                    _=translate_call,
+                    **parser_instance.localcontext)
+            except Exception:
+                msg = exceptions.text_error_template().render()
+                _logger.error(msg)
+                raise orm.except_orm(_('Webkit render!'), msg)
+            return (deb, 'html')
+        bin = self.get_lib(cursor, uid)
+        pdf = self.generate_pdf_multi(bin, report_xml, pages)
+        return (pdf, 'pdf')
+
+    def generate_pdf_multi(self, comm_path, report_xml, pages):
+        """Call webkit in order to generate pdf"""
+        tmpdir = tempfile.mkdtemp(prefix='webkit_report')
+        out_filename = os.path.join(tmpdir, "out.pdf")
+        webkit_header = report_xml.webkit_header
+
+        if comm_path:
+            command = [comm_path]
+        else:
+            command = ['wkhtmltopdf']
+
+        command.extend([
+            '--encoding', 'utf-8',
+            '--quiet',
+        ])
+        for key, val in [("--margin-top", webkit_header.margin_top),
+                         ("--margin-bottom", webkit_header.margin_bottom),
+                         ("--margin-right", webkit_header.margin_right),
+                         ("--margin-left", webkit_header.margin_left),
+                         ("--page-size", webkit_header.format),
+                         ("--orientation", webkit_header.orientation)]:
+            if val:
+                command.extend([
+                    key,
+                    str(val).replace(", ", "."),
+                ])
+
+        for idx, (html, head, foot) in pages:
+            body_file = os.path.join(tmpdir, "body{0}.html".format(idx))
+            with open(body_file, "wb") as f:
+                f.write(self._sanitize_html(html))
+            command.extend(["page", body_file])
+
+            if head:
+                head_file = os.path.join(tmpdir, "head{0}.html".format(idx))
+                with open(head_file, "wb") as f:
+                    f.write(self._sanitize_html(head))
+                command.extend(["--header-html", head_file])
+
+            if foot:
+                foot_file = os.path.join(tmpdir, "foot{0}.html".format(idx))
+                with open(foot_file, "wb") as f:
+                    f.write(self._sanitize_html(foot))
+                command.extend(["--footer-html", foot_file])
+
+        command.append(out_filename)
+        stderr_path = os.path.join(tmpdir, "stderr.out")
+        try:
+            print " ".join(command)
+            with open(stderr_path, "w") as stderr_fd:
+                status = subprocess.call(command, stderr=stderr_fd)
+            try:
+                with open(stderr_path, 'r') as fobj:
+                    error_message = fobj.read()
+            except Exception:
+                error_message = _('No diagnosis message was provided')
+            else:
+                error_message = _('The following diagnosis message was '
+                                  'provided:\n') + error_message
+
+            if status:
+                raise orm.except_orm(
+                    _('Webkit error'),
+                    _("The command 'wkhtmltopdf' failed with error code = %s."
+                      "Message: %s") % (status, error_message))
+
+            with open(out_filename, 'rb') as pdf_file:
+                pdf = pdf_file.read()
+        finally:
+            try:
+                shutil.rmtree(tmpdir, log_rmtree_error)
+            except Exception:
+                pass
+        return pdf


### PR DESCRIPTION
This module allows the header and footer of webkit reports to be rendered once per
object in the report. This lets you put information about the current object in the header
or footer.
